### PR TITLE
Update stadux-react peer dependency to support stadux@2.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,6 @@
   "peerDependencies": {
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
-    "stadux": "^1.3.0"
+    "stadux": ">=1.3.0"
   }
 }


### PR DESCRIPTION
Hi! I'm Huan, a developer from the AB project. I am currently working on upgrading nodejs to version 18. However, during the upgrade process, I encountered an error reported by npm. The error states that `stadux-react` requires `stadux@^1.3.0` as a peer dependency, which conflicts with the version `stadux@2.5.0` used in the root project.

Based on my analysis, I believe that `stadux-react` can function properly with `stadux@2.5.0`, just as it did before. To address this issue, I propose updating the `peerDependencies` in `stadux-react` to have a limitation of `>=1.3.0` instead of `^1.3.0`.

I appreciate your review and consideration of this pull request. Thank you!
```
❯ npm install
npm ERR! code ERESOLVE
npm ERR! ERESOLVE could not resolve
npm ERR!
npm ERR! While resolving: stadux-react@1.1.0
npm ERR! Found: stadux@2.5.0
npm ERR! node_modules/stadux
npm ERR!   stadux@"2.5.0" from the root project
npm ERR!
npm ERR! Could not resolve dependency:
npm ERR! peer stadux@"^1.3.0" from stadux-react@1.1.0
npm ERR! node_modules/stadux-react
npm ERR!   stadux-react@"^1.1.0" from the root project
npm ERR!
npm ERR! Conflicting peer dependency: stadux@1.4.0
npm ERR! node_modules/stadux
npm ERR!   peer stadux@"^1.3.0" from stadux-react@1.1.0
npm ERR!   node_modules/stadux-react
npm ERR!     stadux-react@"^1.1.0" from the root project
npm ERR!
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
```